### PR TITLE
fix: fixed frame scroll bar.

### DIFF
--- a/src/components/app/app-frame.vue
+++ b/src/components/app/app-frame.vue
@@ -11,8 +11,8 @@
         <!-- <keep-alive> -->
         <router-view></router-view>
         <!-- </keep-alive> -->
+        <HFooter><appFooter></appFooter></HFooter>
       </Content>
-      <HFooter><appFooter></appFooter></HFooter>
     </Layout>
   </Layout>
   <Modal v-model="openSetting" type="drawer-right">

--- a/src/components/login/index.vue
+++ b/src/components/login/index.vue
@@ -105,11 +105,11 @@
       <div class="login-content">
         <div class="login-title">管理系统</div>
         <div class="login-name login-input">
-          <input type="text" v-model="login.username" autocomplete="off"/>
+          <input type="text" name="username" v-model="login.username" autocomplete="off"/>
           <span class="placeholder" :class="{fixed: login.username != '' && login.username != null}">用户名</span>
         </div>
         <div class="login-password login-input">
-          <input type="password" v-model="login.password" @keyup.enter="submit" autocomplete="off"/>
+          <input type="password" name="password" v-model="login.password" @keyup.enter="submit" autocomplete="off"/>
           <span class="placeholder" :class="{fixed: login.password != '' && login.password != null}">密码</span>
         </div>
         <div class="buttonDiv">

--- a/src/css/app.less
+++ b/src/css/app.less
@@ -5,11 +5,29 @@
 @import (less) "./markdown.less";
 @import (less) "./common.less";
 
-
 body{
   background: #f3f6f8;
   color: rgb(47, 47, 47);
   font-weight: 400;
+}
+
+::-webkit-scrollbar {
+  width: 12px;
+  height: 12px;
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: hsla(0,0%,44%,.06);
+  border-radius: 12px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background-color: @primary-color;
+  border-radius: 12px
+}
+
+html, body {
+  overflow: hidden;
 }
 
 p {

--- a/src/css/frame.less
+++ b/src/css/frame.less
@@ -35,6 +35,10 @@
     .sys-tabs-vue + .h-layout-content {
       margin-top: 45px;
     }
+    .h-layout-content {
+      height: calc(100vh - @layout-header-height);
+      overflow: auto;
+    }
   }
 
   .h-layout-sider-theme-dark .app-logo a{


### PR DESCRIPTION
为了防止切换页面的时候，内容长的页面显示滚动条的时候会导致页面闪烁。
对代码做了如下修改：

1. 禁用了body的滚动条。
2. 将``.h-layout-content``容器设为主要内容区域，并启用滚动条。
3. 美化了滚动条样式。
